### PR TITLE
Support title for experience section

### DIFF
--- a/_includes/experiences.html
+++ b/_includes/experiences.html
@@ -6,7 +6,7 @@
       <i class="fas fa-circle fa-stack-2x"></i>
       <i class="fas fa-briefcase fa-stack-1x fa-inverse"></i>
     </span>
-    Experiences
+    {{ experience.title }}
   </h2>
 
   {% for experience in experiences %}


### PR DESCRIPTION
Would be nice to be able to edit the title of this section. For example, some people prefer "Work Experience" over "Experiences".

I'm not sure how to set a default value so that this change doesn't break existing consumers?