### PR TITLE
Made the site description configurable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,7 @@
 title: My Resume
 url: 'http://webjeda.com'
 baseurl: '/online-cv' #change it according to your repository name
+description: A beautiful Jekyll theme for creating resume
 # Style will be applied only after restarting the build or serve. Just choose one of the options.
 theme_skin: blue # blue turquoise green berry orange ceramic
 chrome_mobile_color: #use hex colors (ex:#1976d2) or leave empty if you don't want a color for chrome mobile searchbar

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,8 @@
   {% endif%}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="A beautiful Jekyll theme for creating resume">
+  <meta name="description" content="{{ site.description |default: "A beautiful
+  Jekyll theme for creating resume" }}">
 
   <!-- Favicon -->
   <link rel="shortcut icon" href="favicon.ico">


### PR DESCRIPTION
I added a config key for the site description. This should make it easier for people unfamiliar with jekyll to change the descrption of their site. This is particularly important when the page is shared in, for instance slack and a teaser is shown, as this teaser typically includes the site description.