### PR TITLE
Fix icon not appearing in print (Issue #120)

### DIFF
--- a/_sass/_print.scss
+++ b/_sass/_print.scss
@@ -36,4 +36,10 @@
        -webkit-print-color-adjust: exact; 
     }
 
+   .fa-inverse,
+   .fa-inverse:after,
+   .fa-inverse:before {
+     color: #ffffff !important;
+   }
+
 }


### PR DESCRIPTION
If resume printed in pdf, section icons does not appear inside circle