### PR TITLE
Prevent overflow into dates

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -186,6 +186,7 @@ p {
     position: relative;
     overflow: hidden;
     margin-bottom: 2px;
+    display: flex;
   }
   .job-title,
   .degree {
@@ -194,12 +195,14 @@ p {
     margin-top: 0;
     margin-bottom: 0;
     font-weight: 500;
+    flex: 75%;
   }
   .time {
     position: absolute;
     right: 0;
     top: 0;
     color: $text-grey;
+    flex: 25%;
   }
   .company,
   .university {


### PR DESCRIPTION
On my adapted template on [rdmolony](https://rdmolony.github.io/cv/) "MAI in Mechanical Engineering" would overflow into "2014 - 2019" at certain resolutions (iPads) as the 'time' `<div>` is not separated from `<h3>` or 'degree'.  Now they are in separate containers using the 'flex' css attribute in the parent `<div>` and in both elements to keep them in two columns