### PR TITLE
fix: Sidebar no avatar problem

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -3,7 +3,7 @@
 
   <div class="profile-container">
 
-    {% if sidebar.name %}
+    {% if sidebar.avatar %}
     <img class="avatar" src="{{ site.baseurl }}/assets/images/{{ sidebar.avatar }}" alt="profile picture" />
     {% endif %}
 


### PR DESCRIPTION
If the user had a name but no avatar there would be empty image tag on the previous version