### PR TITLE
fix: A bug in the OSS contribution's link

### DIFF
--- a/_includes/oss-contributions.html
+++ b/_includes/oss-contributions.html
@@ -21,7 +21,7 @@
 
     <span class="project-title">
       {% if contribution.link %}
-      <a href="{{ project.link }}" target="_blank">{{ contribution.title }}</a>
+      <a href="{{ contribution.link }}" target="_blank">{{ contribution.title }}</a>
       {% else %}
       {{ contribution.title }}
       {% endif %}


### PR DESCRIPTION
a typo that leads a wrong link in the part of the OSS contribution.

now the link in the part of the OSS contributions may refer to the {{ project.link }}, thus, the CV itself.