### PR TITLE
Use jekyll:4.0 to fix build issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   jekyll:
     container_name: online-cv
-    image: jekyll/jekyll:3.8
+    image: jekyll/jekyll:4.0
     command: jekyll serve --watch --force_polling --verbose --livereload --host 0.0.0.0
     volumes:
       - .:/srv/jekyll


### PR DESCRIPTION
Running `docker-compose up` leads to the following error messages: 

```
online-cv-jekyll-1  | Warning: the running version of Bundler (2.0.2) is older than the version that created the lockfile (2.3.19). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
online-cv-jekyll-1  | Fetching gem metadata from https://rubygems.org/..........
online-cv-jekyll-1  | Fetching gem metadata from https://rubygems.org/.
online-cv-jekyll-1  | Resolving dependencies...........
online-cv-jekyll-1  | Bundler could not find compatible versions for gem "ruby":
online-cv-jekyll-1  |   In Gemfile:
online-cv-jekyll-1  |     ruby
online-cv-jekyll-1  | 
online-cv-jekyll-1  |     jekyll was resolved to 3.9.2, which depends on
online-cv-jekyll-1  |       jekyll-watch (~> 2.0) was resolved to 2.2.1, which depends on
online-cv-jekyll-1  |         listen (~> 3.0) was resolved to 3.7.1, which depends on
online-cv-jekyll-1  | rb-inotify (~> 0.9, >= 0.9.10) was resolved to 0.10.1, which depends
online-cv-jekyll-1  | on
online-cv-jekyll-1  |             ffi (~> 1.0) was resolved to 1.15.5, which depends on
online-cv-jekyll-1  |               ruby (>= 2.4, < 3.2.dev) x64-unknown
online-cv-jekyll-1  | 
online-cv-jekyll-1  |     github-pages was resolved to 227, which depends on
online-cv-jekyll-1  |       nokogiri (>= 1.13.6, < 2.0) was resolved to 1.13.8, which depends on
online-cv-jekyll-1  |         ruby (>= 3.1, < 3.2.dev) x64-unknown
online-cv-jekyll-1  | 
online-cv-jekyll-1  |     github-pages was resolved to 227, which depends on
online-cv-jekyll-1  |       nokogiri (>= 1.13.6, < 2.0) was resolved to 1.13.8, which depends on
online-cv-jekyll-1  |         ruby (>= 2.6, < 3.2.dev) x86_64-linux
online-cv-jekyll-1  | 
online-cv-jekyll-1  |     github-pages was resolved to 227, which depends on
online-cv-jekyll-1  |       nokogiri (>= 1.13.6, < 2.0) was resolved to 1.13.8, which depends on
online-cv-jekyll-1  |         ruby (>= 2.6, < 3.2.dev) arm64-darwin-22
online-cv-jekyll-1  | 
online-cv-jekyll-1  | Could not find gem 'ruby (>= 3.1, < 3.2.dev)', which is required by gem
online-cv-jekyll-1  | 'nokogiri (>= 1.13.6, < 2.0)', in any of the relevant sources:
online-cv-jekyll-1  |   the local ruby installation

```

The problem can be resolved using the jekyll:4.0 image in the docker-compose file.