### PR TITLE
Add webrick to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # gem "rails"
 gem "jekyll"
 gem 'github-pages'
+gem 'webrick'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,11 +206,15 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    mini_portile2 (2.8.4)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.2)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -249,6 +253,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -258,6 +263,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll
+  webrick
 
 BUNDLED WITH
    2.3.19


### PR DESCRIPTION
Bumped into this error when running `docker-compose up`:
...
_/usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)_
...
This is related to [this](https://github.com/jekyll/jekyll/issues/8523) issue

Adding _webrick_ to the Gemfile resolves the error