### PR TITLE
feat: add Bluesky social network to the contact sidebar

### DIFF
--- a/_data/data.yml
+++ b/_data/data.yml
@@ -24,6 +24,7 @@ sidebar:
   telegram: # add your nickname without '@' sign
   gitlab:
   bitbucket:
+  bluesky: '@jekyllrb.bsky.social' # Specify your full Bluesky handle
   twitter: '@jekyllrb'
   stack-overflow: # Number/Username, e.g. 123456/alandoe
   codewars:

--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -72,7 +72,14 @@
       <a href="https://twitter.com/{{ sidebar.twitter }}" target="_blank">{{ sidebar.twitter }}</a>
     </li>
     {% endif %}
-
+    
+    {% if sidebar.bluesky %}
+    {% assign bluesky_handle = sidebar.bluesky | remove: '@' %}
+    <li class="bluesky"><i class="fab fa-bluesky"></i>
+      <a href="https://bsky.app/profile/{{ bluesky_handle }}" target="_blank">{{ sidebar.bluesky }}</a>
+    </li>
+    {% endif %}
+    
     {% if sidebar.mastodon %}
     {% assign mastodon_handle = sidebar.mastodon | split: '/' %}
     <li class="mastodon"><i class="fab fa-mastodon"></i>


### PR DESCRIPTION
Introduces support for displaying a Bluesky profile link in the contact sidebar.
The implementation adds a new `bluesky` field to the `sidebar` section, the value of this field should be the user's full Bluesky handle, including the "@" symbol.
