### PR TITLE
enable baseurl for GitHub Pages project site deployment

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,7 @@ title: My Resume
 url: 'http://webjeda.com'
 
 #change it according to your repository name
-# disabling since we are using a custom domain
-#baseurl: '/online-cv' 
+baseurl: '/online-cv'
 
 description: A beautiful Jekyll theme for creating resume
 # Style will be applied only after restarting the build or serve. Just choose one of the options.


### PR DESCRIPTION
Uncomment baseurl: '/online-cv' so CSS and links resolve correctly when hosted at https://<username>.github.io/online-cv/

https://claude.ai/code/session_01XySRSXwC7QTnT8WGWpeNya